### PR TITLE
fix(mobile): scope battery + xcap to desktop targets so Android/iOS builds compile

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -94,8 +94,6 @@ zip = "0.6"
 quick-xml = "0.37"
 rusqlite = { version = "0.31", features = ["bundled", "backup"] }
 image = "0.24"
-# Screenshot capture - optional feature
-xcap = { version = "0.8", optional = true }
 
 # RSS parsing
 roxmltree = "0.20"
@@ -111,9 +109,6 @@ fsrs = "5.2"
 # Environment variables
 dotenvy = "0.15"
 
-# Battery state for adaptive behavior
-battery = "0.7"
-
 # Config directories
 dirs = "5.0"
 
@@ -122,6 +117,20 @@ keyring = "3"
 
 # Encrypted fallback key derivation
 pbkdf2 = "0.12"
+
+# Desktop-only dependencies.
+# The crates below have no Android/iOS backend and fail to compile for those
+# targets, so they are scoped to desktop via a target-specific table:
+#   - `battery` 0.7: emits "Support for this target OS is not implemented yet!"
+#     on android/ios.
+#   - `xcap` 0.8: its `platform` module is empty on iOS/Android, so compiling it
+#     fails with "could not find `platform` in the crate root".
+# On mobile the corresponding Tauri commands are stubbed out (see src/battery.rs
+# and src/screenshot.rs), and the `screenshot` cargo feature is a no-op there
+# because `xcap` is absent from the dependency graph on those targets.
+[target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
+battery = "0.7"
+xcap = { version = "0.8", optional = true }
 
 [features]
 # Disable custom-protocol to use http://localhost instead of tauri://

--- a/src-tauri/src/battery.rs
+++ b/src-tauri/src/battery.rs
@@ -9,6 +9,12 @@ pub struct BatteryState {
     pub is_charging: bool,
 }
 
+// Desktop implementation: the `battery` crate has no Android/iOS backend
+// (it fails to compile there with "Support for this target OS is not
+// implemented yet!"), so it is a desktop-only dependency. On mobile we expose
+// the same Tauri command but return a harmless default — the frontend already
+// tolerates "no battery detected".
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 /// Tauri command: read current battery state via the `battery` crate.
 ///
 /// Returns a default "plugged in" state if the battery crate fails or if
@@ -44,5 +50,19 @@ pub fn get_battery_state() -> BatteryState {
             level: 1.0,
             is_charging: true, // Assume plugged-in when we can't detect
         },
+    }
+}
+
+// Mobile stub: the `battery` crate is unavailable on android/ios (see the
+// target-specific dependency in Cargo.toml). Mobile apps query battery via the
+// OS directly if needed; the frontend treats `is_present: false` as "plugged
+// in / unknown", which is the same fallback the desktop path uses on error.
+#[cfg(any(target_os = "android", target_os = "ios"))]
+#[tauri::command]
+pub fn get_battery_state() -> BatteryState {
+    BatteryState {
+        is_present: false,
+        level: 1.0,
+        is_charging: true,
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -35,7 +35,10 @@ mod utils;
 mod notebooklm;
 mod pocket_tts;
 mod battery;
-#[cfg(feature = "screenshot")]
+// `screenshot` requires the `xcap` crate, which only has a backend on desktop
+// (see the target-specific dependency in Cargo.toml). On android/ios the
+// `screenshot` cargo feature is a no-op and the module is excluded entirely.
+#[cfg(all(feature = "screenshot", not(any(target_os = "android", target_os = "ios"))))]
 mod screenshot;
 
 #[cfg(test)]
@@ -1126,13 +1129,13 @@ pub fn run() {
             commands::glm_start_ollama_runtime,
             commands::glm_stop_ollama_runtime,
             commands::glm_pull_ollama_model,
-            #[cfg(feature = "screenshot")]
+            #[cfg(all(feature = "screenshot", not(any(target_os = "android", target_os = "ios"))))]
             screenshot::capture_screenshot,
-            #[cfg(feature = "screenshot")]
+            #[cfg(all(feature = "screenshot", not(any(target_os = "android", target_os = "ios"))))]
             screenshot::capture_screen_by_index,
-            #[cfg(feature = "screenshot")]
+            #[cfg(all(feature = "screenshot", not(any(target_os = "android", target_os = "ios"))))]
             screenshot::capture_app_window,
-            #[cfg(feature = "screenshot")]
+            #[cfg(all(feature = "screenshot", not(any(target_os = "android", target_os = "ios"))))]
             screenshot::get_screen_info,
             transcription::get_transcription_profiles,
             transcription::download_transcription_model,


### PR DESCRIPTION
## Problem

The Android and iOS mobile CI builds (`mobile-build.yml`) have been failing on every run for a long time. Root cause from the latest failed run:

- **Android**: `battery` 0.7 has no Android backend → `error: Support for this target OS is not implemented yet!`
- **iOS**: `xcap` 0.8 (screenshot capture) has no iOS backend → `error[E0433]: could not find `platform` in the crate root`

Both crates only support Linux/macOS/Windows. The mobile builds were including them unconditionally because they were in the regular `[dependencies]` table.

## Fix

Scope `battery` and `xcap` to desktop via a target-specific dependency table:

```toml
[target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
battery = "0.7"
xcap = { version = "0.8", optional = true }
```

And gate the source that uses them:

- `battery.rs`: no-op `get_battery_state` stub on mobile (frontend already tolerates "no battery" = plugged-in/unknown).
- `screenshot.rs` module + command registrations: excluded on mobile (xcap unavailable).

The `screenshot` cargo feature becomes a no-op on mobile (xcap is absent from the graph, so the feature resolves to nothing). Desktop builds are unchanged.

## Verification

- `cargo check` on desktop host: ✅ clean
- `cargo tree --target aarch64-linux-android`: ✅ resolves, `xcap`/`battery` absent
- `cargo tree --target aarch64-apple-ios`: ✅ resolves, `xcap`/`battery` absent
- `cargo tree` (desktop): ✅ both `battery` and `xcap` still present

Full cross-compilation (NDK/Xcode) must be confirmed by the mobile-build workflow run on this PR.

## Impact

Once merged, the mobile CI will produce a signed APK attached to every `v*` release tag (self-signed keystore fallback if `ANDROID_KEYSTORE_*` secrets are absent). iOS remains a signed-build-or-simulator-validation path as before.