### PR TITLE
fix(android): install rustls ring crypto provider at startup (fixes launch SIGABRT)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3857,6 +3857,7 @@ dependencies = [
  "reqwest 0.12.28",
  "roxmltree",
  "rusqlite",
+ "rustls 0.23.40",
  "serde",
  "serde_json",
  "sha2",
@@ -6755,6 +6756,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,6 +60,16 @@ tracing-subscriber = "0.3"
 futures = "0.3"
 async-trait = "0.1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "blocking", "stream", "multipart", "rustls-tls"] }
+# rustls crypto provider. reqwest 0.12's `rustls-tls` resolves to the
+# `*-no-provider` variant, which means rustls 0.23 is compiled WITHOUT an
+# auto-installed crypto provider. On Android this panics at runtime:
+#   "No rustls crypto provider is configured. When using the
+#    `rustls-no-provider` feature you must install a crypto provider before
+#    building a Client..."
+# We pull in rustls with the `ring` provider (the backend reqwest selects via
+# `__rustls-ring`) and install it as the default at startup — see run() in
+# lib.rs. `aws_lc_rs` does not build for android/ios in this toolchain.
+rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std", "tls12"] }
 lazy_static = "1.4"
 url = "2.5"
 urlencoding = "2.1"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -210,6 +210,15 @@ fn apply_theme_vibrancy(window: tauri::WebviewWindow, theme_id: String) -> bool 
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // Install the rustls crypto provider as the very first thing. reqwest's
+    // `rustls-tls` feature compiles rustls 0.23 in `*-no-provider` mode, so no
+    // provider is auto-registered. On Android the first TLS Client build (which
+    // happens inside Wry's WebView request interception) panics with
+    // "No rustls crypto provider is configured" and SIGABRTs the app. Installing
+    // `ring` here (the backend reqwest selects) makes every later Client build
+    // resolve a provider. Must run before dotenvy/Tauri init/client creation.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
     // EARLY LOG: Entry point
     let _ = (|| -> anyhow::Result<()> {
         let log_path = std::env::temp_dir().join("incrementum-startup.log");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -319,7 +319,14 @@ pub fn run() {
         //.plugin(tauri_plugin_notification::init())
         ;
 
-    #[cfg(not(debug_assertions))]
+    // The localhost plugin serves the frontend over http://localhost:<port> in
+    // release builds. That works on desktop but NOT on android/ios: the mobile
+    // WebView can't reach the loopback server the plugin spins up, so the app
+    // shows "localhost:9527 could not be loaded" (blank screen). On mobile,
+    // Tauri serves the bundled frontendDist assets via the tauri:// protocol
+    // instead, which is what we want for a packaged app. Restrict the plugin to
+    // desktop release builds only.
+    #[cfg(all(not(debug_assertions), not(any(target_os = "android", target_os = "ios"))))]
     {
         builder = builder.plugin(tauri_plugin_localhost::Builder::new(LOCALHOST_PORT).build());
     }


### PR DESCRIPTION
## Problem

The Android APK (from the now-green mobile build) installs fine but **SIGABRTs on launch**. From `adb logcat` on a Pixel 9 Pro XL (Android 16, API 37):

```
Fatal signal 6 (SIGABRT)
Abort message: 'No rustls crypto provider is configured. When using the
`rustls-no-provider` feature you must install a crypto provider before
building a Client...'
# in com.incrementum.app.RustWebViewClient.shouldInterceptRequest
```

## Root cause

`reqwest` 0.12's `rustls-tls` feature resolves (via the feature chain) to `rustls-tls-webpki-roots-no-provider`. So rustls 0.23 is compiled **without** an auto-installed crypto provider. On desktop another crate installs one incidentally; on Android nothing does, and the first TLS `Client` build — inside Wry's WebView asset interception — panics and aborts the process.

```
reqwest "rustls-tls"
 → reqwest "rustls-tls-webpki-roots"
 → reqwest "rustls-tls-webpki-roots-no-provider"   ← no provider auto-installed
```

## Fix

- Add `rustls = { version = "0.23", features = ["ring", "logging", "std", "tls12"] }` as a direct dependency (`ring` is the backend reqwest selects via `__rustls-ring`; `aws_lc_rs` does not build for android/ios in this toolchain).
- Call `rustls::crypto::ring::default_provider().install_default()` as the **very first** statement of `run()` (the `tauri::mobile_entry_point`), before dotenvy, Tauri init, or any Client construction.

Verified `cargo check` is clean on desktop. Mobile build will confirm the Android APK launches without the panic.