### PR TITLE
fix(android): serve frontend via tauri:// custom protocol (localhost plugin breaks mobile WebView)

### DIFF
--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -241,7 +241,13 @@ jobs:
           export PATH="$HOME/.cargo/bin:$PATH"
           echo "Using cargo: $CARGO"
           "$CARGO" --version
-          npm run tauri -- android build --ci --target aarch64 --apk 2>&1 | tee artifacts/mobile-logs/android-build.log
+          # --features custom-protocol: serve the bundled frontendDist via the
+          # tauri:// protocol instead of the localhost plugin. On mobile the
+          # WebView can't reach tauri-plugin-localhost's loopback server, so we
+          # must use the custom protocol + bundled assets. (tauri-plugin-localhost
+          # is a desktop-only dependency; see Cargo.toml.) The tauri CLI passes
+          # its --features through to the cargo build it runs.
+          npm run tauri -- android build --ci --target aarch64 --apk --features custom-protocol 2>&1 | tee artifacts/mobile-logs/android-build.log
 
       - name: Sign Android APK (release)
         if: steps.android_mode.outputs.mode == 'provided-keystore' || steps.android_mode.outputs.mode == 'self-signed'

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,7 +26,6 @@ tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2.7"
 tauri-plugin-shell = "2"
 tauri-plugin-notification = "2"
-tauri-plugin-localhost = "2"
 tauri-plugin-global-shortcut = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
@@ -141,6 +140,13 @@ pbkdf2 = "0.12"
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 battery = "0.7"
 xcap = { version = "0.8", optional = true }
+# Desktop-only: tauri-plugin-localhost serves the frontend over
+# http://localhost:<port> so YouTube iframe embeds work (the `tauri://`
+# custom protocol is treated as a remote origin and blocks iframes). On
+# android/ios the mobile WebView cannot reach the loopback server, so the app
+# shows "localhost:9527 could not be loaded". Mobile uses the bundled
+# frontendDist via tauri:// instead (see the `custom-protocol-mobile` feature).
+tauri-plugin-localhost = "2"
 
 [features]
 # Disable custom-protocol to use http://localhost instead of tauri://

--- a/src-tauri/gen/android/buildSrc/src/main/java/com/incrementum/app/kotlin/BuildTask.kt
+++ b/src-tauri/gen/android/buildSrc/src/main/java/com/incrementum/app/kotlin/BuildTask.kt
@@ -46,9 +46,19 @@ open class BuildTask : DefaultTask() {
         val ndkHome = System.getenv("ANDROID_NDK_HOME")
             ?: System.getenv("NDK_HOME")
             ?: throw GradleException("NDK_HOME/ANDROID_NDK_HOME must be set")
-        val linkerPath = "$ndkHome/toolchains/llvm/prebuilt/linux-x86_64/bin/${clangTriple}24-clang"
+        // The NDK lays out host-specific toolchain binaries under
+        //   $NDK/toolchains/llvm/prebuilt/<host-tag>/bin/
+        // where <host-tag> is e.g. "linux-x86_64" on Linux, "darwin-x86_64"
+        // on macOS, "windows-x86_64" on Windows. The upstream template
+        // hardcodes "linux-x86_64", which breaks local builds on macOS/Windows.
+        // Detect the actual host tag by listing the prebuilt dir.
+        val prebuiltDir = File("$ndkHome/toolchains/llvm/prebuilt")
+        val hostTag = prebuiltDir.listFiles()?.firstOrNull { it.isDirectory }?.name
+            ?: throw GradleException("NDK prebuilt dir not found: ${prebuiltDir.absolutePath}")
+        val ndkBinDir = "$ndkHome/toolchains/llvm/prebuilt/$hostTag/bin"
+        val linkerPath = "$ndkBinDir/${clangTriple}24-clang"
 
-        val arPath = "$ndkHome/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar"
+        val arPath = "$ndkBinDir/llvm-ar"
         val cargoTargetEnv = cargoTarget.uppercase().replace('-', '_')
 
         val cargoExecutable = resolveCargoExecutable()
@@ -84,6 +94,18 @@ open class BuildTask : DefaultTask() {
             "build", "--lib", "--target", cargoTarget
         )
         if (release) argv += "--release"
+        // Forward cargo features so the Gradle-spawned rustBuild matches the
+        // build the Tauri CLI ran first. Without this, rustBuild recompiles
+        // WITHOUT --features, which drops `tauri/custom-protocol` and produces a
+        // .so with NO embedded frontend assets (blank screen on the device) that
+        // then overwrites the good .so the CLI built. Default to
+        // "custom-protocol" for mobile since the tauri:// protocol is how the
+        // bundled frontendDist is served on android/ios (tauri-plugin-localhost
+        // is desktop-only). Override via the RUST_BUILD_FEATURES env var.
+        val features = System.getenv("RUST_BUILD_FEATURES") ?: "custom-protocol"
+        if (features.isNotBlank()) {
+            argv += listOf("--features", features)
+        }
         // Quote each argv element for the shell.
         val cmdLine = argv.joinToString(" ") { "'" + it.replace("'", "'\\''") + "'" }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -680,12 +680,18 @@ pub fn run() {
                 });
 
                 if let Some(window) = app.get_webview_window("main") {
-                    if !cfg!(debug_assertions) {
-                        if let Ok(url) =
-                            Url::parse(&format!("http://localhost:{LOCALHOST_PORT}/"))
-                        {
-                            let _ = window.navigate(url);
-                        }
+                    // On desktop release builds the frontend is served over
+                    // http://localhost via tauri-plugin-localhost, so navigate
+                    // the main window there. On android/ios the localhost plugin
+                    // is absent and the frontend is served from the bundled
+                    // frontendDist via the tauri:// protocol — navigating to
+                    // localhost:9527 there leaves the screen blank ("could not
+                    // be loaded"), so skip the redirect on mobile.
+                    #[cfg(all(not(debug_assertions), not(any(target_os = "android", target_os = "ios"))))]
+                    if let Ok(url) =
+                        Url::parse(&format!("http://localhost:{LOCALHOST_PORT}/"))
+                    {
+                        let _ = window.navigate(url);
                     }
                     #[cfg(all(feature = "devtools", not(any(target_os = "ios", target_os = "android"))))]
                     if std::env::var("INCREMENTUM_OPEN_DEVTOOLS").is_ok() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -319,13 +319,13 @@ pub fn run() {
         //.plugin(tauri_plugin_notification::init())
         ;
 
-    // The localhost plugin serves the frontend over http://localhost:<port> in
-    // release builds. That works on desktop but NOT on android/ios: the mobile
-    // WebView can't reach the loopback server the plugin spins up, so the app
-    // shows "localhost:9527 could not be loaded" (blank screen). On mobile,
-    // Tauri serves the bundled frontendDist assets via the tauri:// protocol
-    // instead, which is what we want for a packaged app. Restrict the plugin to
-    // desktop release builds only.
+    // Desktop release builds serve the frontend over http://localhost via the
+    // tauri-plugin-localhost plugin (a desktop-only dependency). This sidesteps
+    // the `tauri://` custom-protocol being treated as a remote origin, which
+    // otherwise breaks YouTube iframe embeds (Error 153). On android/ios the
+    // plugin is absent from the dependency graph and the mobile build passes
+    // --features custom-protocol, so Tauri serves the bundled frontendDist via
+    // tauri:// instead — the mobile WebView can't reach the loopback server.
     #[cfg(all(not(debug_assertions), not(any(target_os = "android", target_os = "ios"))))]
     {
         builder = builder.plugin(tauri_plugin_localhost::Builder::new(LOCALHOST_PORT).build());


### PR DESCRIPTION
## Problem

PR #20's runtime `.plugin()` gate was insufficient. The Tauri CLI injects the `http://localhost:9527` webview URL at **build time** whenever `tauri-plugin-localhost` is in the dependency graph — regardless of whether `.plugin()` is actually called. So the installed APK still showed:

```
Webview ready at Ok(Url { scheme: http, host: localhost, port: 9527 })
→ 'localhost:9527 could not be loaded' (blank screen)
```

## Fix

1. **Make `tauri-plugin-localhost` a desktop-only Cargo dependency** (target-specific table, like `battery`/`xcap`). Now it's absent from the android/ios dependency graph entirely — verified `cargo tree --target aarch64-linux-android` shows 0 occurrences.

2. **Enable `tauri/custom-protocol` for the mobile build** (`--features custom-protocol` in mobile-build.yml). Tauri then serves the bundled `frontendDist` via the `tauri://` protocol — the one the mobile WebView can actually reach.

Desktop is unchanged: keeps the localhost plugin (release) for YouTube iframe compatibility and does NOT enable custom-protocol.