### PR TITLE
fix: database pool timeout when deleting cards with sync enabled

### DIFF
--- a/src-tauri/src/database/connection.rs
+++ b/src-tauri/src/database/connection.rs
@@ -111,12 +111,20 @@ impl Database {
             // NORMAL synchronous with WAL gives good durability/performance trade-off
             .synchronous(sqlx::sqlite::SqliteSynchronous::Normal);
 
-        // Create connection pool — 5 is sufficient for a single-user desktop app
+        // Create connection pool — increased to 20 to handle concurrent
+        // user operations (e.g. bulk delete) alongside sync processes (Yjs
+        // CRDT sync, localStorage sync, file sync) without exhausting the
+        // pool and causing "pool timed out" errors on heavy workloads.
         let pool = PoolOptions::<Sqlite>::new()
-            .max_connections(5)
-            .acquire_timeout(Duration::from_secs(30))
+            .max_connections(20)
+            .acquire_timeout(Duration::from_secs(60))
             .connect_with(options)
-            .await?;
+            .await.map_err(|e| {
+                IncrementumError::Internal(format!(
+                    "Database connection pool failed (check if another process has the DB locked): {}",
+                    e
+                ))
+            })?;
 
         // Close the pool if any subsequent step fails so we don't leave a
         // half-initialized connection pool around after returning an error.

--- a/src/components/settings/SyncSettings.tsx
+++ b/src/components/settings/SyncSettings.tsx
@@ -449,6 +449,38 @@ export function SyncSettings() {
             {t("syncSettings.scanToJoinHint")}
           </div>
         </div>
+
+        {/* Real-time (Yjs CRDT) sync toggle */}
+        <div className="border-t border-border pt-4 mt-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <ArrowsClockwise className="w-4 h-4 text-primary" />
+              <div>
+                <p className="text-sm font-medium text-foreground">Real-time sync</p>
+                <p className="text-xs text-muted-foreground">
+                  Sync data across devices in real time via WebSocket. Turn off to reduce network
+                  connections when you only use this device.
+                </p>
+              </div>
+            </div>
+            <label className="relative inline-flex items-center cursor-pointer">
+              <input
+                type="checkbox"
+                className="sr-only peer"
+                checked={syncSettings.yjs.enabled}
+                onChange={(e) =>
+                  updateSettings({
+                    sync: {
+                      ...syncSettings,
+                      yjs: { enabled: e.target.checked },
+                    },
+                  })
+                }
+              />
+              <div className="w-11 h-6 bg-muted peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-primary/20 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-primary"></div>
+            </label>
+          </div>
+        </div>
       </div>
 
       {showScanner && (

--- a/src/config/defaultSettings.ts
+++ b/src/config/defaultSettings.ts
@@ -94,6 +94,9 @@ export const defaultSettings: Settings = {
       intervalMinutes: 0,
       lastSync: 0,
     },
+    yjs: {
+      enabled: true,
+    },
   },
 
   api: {

--- a/src/lib/yjsSync.ts
+++ b/src/lib/yjsSync.ts
@@ -3,6 +3,7 @@ import { WebsocketProvider } from "y-websocket";
 import { IndexeddbPersistence } from "y-indexeddb";
 import { EncryptedWebsocketProvider } from "./sync/encryptedProvider";
 import { getCachedSubKeys } from "./sync/roomCrypto";
+import { useSettingsStore } from "../stores/settingsStore";
 
 type YjsSyncState = {
   doc: Y.Doc;
@@ -28,6 +29,17 @@ function isSyncDebugEnabled(): boolean {
   if (import.meta.env.VITE_DEBUG_NETWORK === "1") return true;
   if (typeof window === "undefined") return false;
   return localStorage.getItem("incrementum.debug.network") === "1";
+}
+
+/** Read the user's preference for Yjs CRDT sync from the settings store.
+ *  Defaults to true if the setting is missing or the store isn't ready yet. */
+function isYjsSyncEnabled(): boolean {
+  try {
+    const state = useSettingsStore.getState();
+    return state?.settings?.sync?.yjs?.enabled ?? true;
+  } catch {
+    return true;
+  }
 }
 
 function generateRoomId(): string {
@@ -194,11 +206,23 @@ export async function getYjsSync(): Promise<YjsSyncState> {
         persistence = null;
       }
 
-      const provider = await buildProvider(url, room, doc);
+      const yjsEnabled = isYjsSyncEnabled();
+
+      if (!yjsEnabled) {
+        console.info(
+          "[YjsSync] Yjs sync is disabled by user setting. Creating offline-only doc.",
+        );
+      }
+
+      const provider = yjsEnabled
+        ? await buildProvider(url, room, doc)
+        : new WebsocketProvider(url, room, doc, { connect: false });
 
       if (isSyncDebugEnabled()) {
         console.debug("[YjsSync] provider constructed", {
-          encrypted: provider !== undefined && (provider as unknown as { __encrypted?: boolean }).__encrypted === true,
+          encrypted:
+            yjsEnabled &&
+            (provider as unknown as { __encrypted?: boolean }).__encrypted === true,
         });
       }
 
@@ -224,70 +248,81 @@ export async function getYjsSync(): Promise<YjsSyncState> {
         persistence,
         url,
         room,
-        encrypted: (provider as unknown as { __encrypted?: boolean }).__encrypted === true,
+        encrypted:
+          yjsEnabled &&
+          (provider as unknown as { __encrypted?: boolean }).__encrypted === true,
         visibilityCleanup: null,
       };
 
-      let idleTimer: ReturnType<typeof setTimeout> | null = null;
-      const IDLE_MS = 5 * 60 * 1000; // 5 minutes
-      let disconnectedFromIdle = false;
+      // Only set up idle timer & visibility reconnect when sync is enabled.
+      // When disabled, the provider was created with { connect: false } and
+      // should stay disconnected indefinitely (offline-only mode).
+      if (yjsEnabled) {
+        let idleTimer: ReturnType<typeof setTimeout> | null = null;
+        const IDLE_MS = 5 * 60 * 1000; // 5 minutes
+        let disconnectedFromIdle = false;
 
-      function resetIdleTimer() {
-        if (idleTimer) clearTimeout(idleTimer);
-        idleTimer = setTimeout(() => {
-          if (provider.shouldConnect && provider.wsconnected) {
-            provider.disconnect();
-            disconnectedFromIdle = true;
-            if (isSyncDebugEnabled()) {
+        function resetIdleTimer() {
+          if (idleTimer) clearTimeout(idleTimer);
+          idleTimer = setTimeout(() => {
+            if (provider.shouldConnect && provider.wsconnected) {
+              provider.disconnect();
+              disconnectedFromIdle = true;
+              if (isSyncDebugEnabled()) {
+              }
             }
-          }
-        }, IDLE_MS);
-      }
-
-      function reconnectIfNeeded() {
-        if (disconnectedFromIdle && !provider.wsconnected) {
-          provider.connect();
-          disconnectedFromIdle = false;
-          if (isSyncDebugEnabled()) {
-          }
+          }, IDLE_MS);
         }
-        resetIdleTimer();
-      }
 
-      // Listen for local document updates to reset the idle timer
-      doc.on("update", () => {
-        reconnectIfNeeded();
-      });
-
-      // Disconnect when page is hidden, reconnect when visible
-      function handleVisibilityChange() {
-        if (document.hidden) {
-          if (provider.wsconnected) {
-            provider.disconnect();
-            if (idleTimer) clearTimeout(idleTimer);
-            if (isSyncDebugEnabled()) {
-            }
-          }
-        } else {
-          if (!provider.wsconnected) {
+        function reconnectIfNeeded() {
+          if (disconnectedFromIdle && !provider.wsconnected) {
             provider.connect();
-            resetIdleTimer();
+            disconnectedFromIdle = false;
             if (isSyncDebugEnabled()) {
             }
           }
+          resetIdleTimer();
         }
-      }
-      document.addEventListener("visibilitychange", handleVisibilityChange);
-      // Track the listener so resetYjsSync() can detach it on teardown — without
-      // this, every room rebuild leaks a visibilitychange handler that keeps
-      // calling disconnect()/connect() on a destroyed provider.
-      if (instance) {
-        instance.visibilityCleanup = () => {
-          document.removeEventListener("visibilitychange", handleVisibilityChange);
-        };
-      }
 
-      resetIdleTimer();
+        // Listen for local document updates to reset the idle timer
+        doc.on("update", () => {
+          reconnectIfNeeded();
+        });
+
+        // Disconnect when page is hidden, reconnect when visible
+        function handleVisibilityChange() {
+          if (document.hidden) {
+            if (provider.wsconnected) {
+              provider.disconnect();
+              if (idleTimer) clearTimeout(idleTimer);
+              if (isSyncDebugEnabled()) {
+              }
+            }
+          } else {
+            if (!provider.wsconnected) {
+              provider.connect();
+              resetIdleTimer();
+              if (isSyncDebugEnabled()) {
+              }
+            }
+          }
+        }
+        document.addEventListener("visibilitychange", handleVisibilityChange);
+        // Track the listener so resetYjsSync() can detach it on teardown — without
+        // this, every room rebuild leaks a visibilitychange handler that keeps
+        // calling disconnect()/connect() on a destroyed provider.
+        if (instance) {
+          instance.visibilityCleanup = () => {
+            document.removeEventListener("visibilitychange", handleVisibilityChange);
+          };
+        }
+
+        resetIdleTimer();
+      } else {
+        console.info(
+          "[YjsSync] Yjs sync is disabled — visibility reconnect & idle timer skipped",
+        );
+      }
 
       return instance;
     } catch (initError) {

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -793,16 +793,28 @@ export const useSettingsStore = create<SettingsState>()(
     }),
     {
       name: "incrementum-settings",
-      version: 3,
+      version: 4,
       migrate: (persisted: unknown, version: number) => {
+        const p = (persisted ?? {}) as Partial<Settings> & { settings?: Partial<Settings> };
+        const root = p.settings ?? p;
         // v2 -> v3: the floating Document Assistant mic orb used to default to ON.
         // It eats screen space and most users never used it, so it now defaults to
         // OFF and is opt-in via Settings → AI. Reset any previously persisted value
         // so existing users also get the new default.
-        const p = (persisted ?? {}) as Partial<Settings> & { settings?: Partial<Settings> };
-        const root = p.settings ?? p;
         if (root?.ai && version < 3) {
           root.ai.pwaAssistantButtonEnabled = false;
+        }
+        // v3 -> v4: ensure the yjs sync settings field exists with defaults.
+        // The onRehydrateStorage merge already applies defaults, but we
+        // explicitly seed it here so the toggle renders correctly even if a
+        // user opens Settings before the rehydration callback fires.
+        if (version < 4) {
+          if (root?.sync) {
+            root.sync = {
+              ...root.sync,
+              yjs: { enabled: true },
+            };
+          }
         }
         return persisted as SettingsState;
       },

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -122,6 +122,12 @@ export interface SyncSettings {
     intervalMinutes: number;
     lastSync: number;
   };
+  /** Yjs CRDT-based real-time sync. Defaults to enabled for backward
+   *  compatibility; toggle off in Settings → Sync to reduce network
+   *  connections and DB pool contention when cross-device sync isn't needed. */
+  yjs: {
+    enabled: boolean;
+  };
 }
 
 // API Settings


### PR DESCRIPTION
## Problem

When a user performs a bulk delete operation (e.g. removing an imported SuperMemo collection), the SQLite connection pool could be exhausted by concurrent operations from:

1. The delete operation itself (card deletion + cascade + cache invalidation)
2. Yjs CRDT sync (WebSocket -> provider -> IndexedDB persist)
3. LocalStorage sync (localStorage -> indexedDB persistence)
4. File sync (downloading pending attachments)

This leads to: `pool timed out while waiting for an open connection` (HTTP 503).

## Root Cause

- The SQLite pool was capped at **5 connections** with a **30-second** acquire timeout -- insufficient for the concurrency spike during bulk operations
- Yjs CRDT sync automatically connected a WebSocket to the sync relay on startup, consuming a DB connection even when the user only needed local/offline use
- No user-facing control existed to disable real-time sync for users who don't need cross-device synchronization

## Changes

### 1. Database pool tuning (backend/connection.rs)
- Pool size: **5 -> 20**
- Acquire timeout: **30s -> 60s**
- Better error message to help diagnose if another process has the DB locked

### 2. Yjs CRDT sync toggle (full stack)
- **Type** (types/settings.ts): Added `sync.yjs.enabled` boolean field
- **Default** (config/defaultSettings.ts): `enabled: true` (preserves existing behavior)
- **Logic** (lib/yjsSync.ts): When `enabled` is `false`:
  - Creates WebsocketProvider with `{ connect: false }` (no WebSocket connection)
  - Skips the idle timer and visibility-change reconnect logic entirely
  - Still keeps Y.Doc + IndexedDB persistence for full offline functionality
- **UI** (components/settings/SyncSettings.tsx): Added a toggle switch in the Device sync card labeled "Real-time sync" with description explaining when to turn it off
- **Migration** (stores/settingsStore.ts): Settings store version 3->4 with migration seeding the new field

## Testing

- [ ] Verify bulk delete no longer triggers "pool timed out" on a production-like dataset
- [ ] Toggle "Real-time sync" off -> verify WebSocket does not connect (devtools -> Network -> WS)
- [ ] Toggle back on -> verify WebSocket reconnects
- [ ] Verify existing users with persisted settings v3 are migrated to v4 correctly

Closes # (add issue number if applicable)

Co-Authored-By: GenericAgent <bot@gaagent.ai>
